### PR TITLE
build: made dev scripts compatible with windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/parser": "^3.4.0",
     "babel-loader": "^8.1.0",
+    "cross-env": "^7.0.2",
     "electron": "^8.2.2",
     "eslint": "^7.3.1",
     "eslint-config-prettier": "^6.11.0",
@@ -47,7 +48,6 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
-    "cross-env": "^7.0.2",
     "electron-store": "^5.2.0",
     "polished": "^3.6.5",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A beautiful Redis GUI.",
   "main": "./dist/main.js",
   "scripts": {
-    "dev:electron": "NODE_ENV=development webpack --config webpack/electron.webpack.js --mode development && electron .",
-    "dev:react": "NODE_ENV=development webpack-dev-server --config webpack/react.webpack.js --mode development",
+    "dev:electron": "cross-env NODE_ENV=development webpack --config webpack/electron.webpack.js --mode development && electron .",
+    "dev:react": "cross-env NODE_ENV=development webpack-dev-server --config webpack/react.webpack.js --mode development",
     "test": "jest"
   },
   "keywords": [],
@@ -47,6 +47,7 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
+    "cross-env": "^7.0.2",
     "electron-store": "^5.2.0",
     "polished": "^3.6.5",
     "react": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -2804,7 +2811,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Fixes
```
'NODE_ENV' is not recognized as an internal or external command
```
No windows, para definir variaveis pelo terminal tem que usar o seguinte formato: `SET NODE_ENV=development`, ao contrário de no MacOS / Linux, que seria apenas `NODE_ENV=development`.
## Erro:
![image](https://user-images.githubusercontent.com/42935195/86295450-8cf99980-bbee-11ea-8f0c-60b271fba729.png)
