### PR TITLE
solving problem with unmaximize() on windows

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -16,7 +16,13 @@ const Header: React.FC = () => {
   const handleMaximize = useCallback(() => {
     const window = remote.getCurrentWindow()
 
-    if (!window.isMaximized()) {
+    const { width: currentWidth, height: currentHeight } = window.getBounds()
+
+    const { width: maxWidth, height: maxHeight } = remote.screen.getPrimaryDisplay().workAreaSize
+
+    const isMaximized = (currentWidth === maxWidth && currentHeight === maxHeight)
+
+    if (!isMaximized) {
       window.maximize()
     } else {
       window.unmaximize()


### PR DESCRIPTION
Resolving a problem with the unmaximize button in windows, when the `BrowserWindow` `frame` option is `false`, `window.isMaximized()`  in `Header` component always returns `false`.