### PR TITLE
refactor(ci): change cache strategy in Github Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,20 @@ jobs:
         with:
           node-version: "12"
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-        
+        run: yarn
+
       - name: Run ESLint
         run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,20 @@ jobs:
         with:
           node-version: "12"
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn
         
       - name: Run Jest
         run: yarn test

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -15,8 +15,20 @@ jobs:
         with:
           node-version: "12"
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn
         
       - name: Run TypeScript
         run: yarn tsc


### PR DESCRIPTION
Currently, even with the cache provided by default, the Github Actions executions were taking more than 40 seconds to execute.
    
I changed the cache strategy to use actions/cache to see if we have improvements.