### PR TITLE
feat(key list): add database keys listing, search and preview

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
       {
         "newlinesBetween": "always",
         "groups": [
+          "/^react/",
           "module",
           ["parent", "sibling", "index"]
         ],

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,7 +1,8 @@
+import { initReactI18next } from 'react-i18next'
+
 import i18n from 'i18next'
 import LanguageDetector from 'i18next-electron-language-detector'
 import Backend from 'i18next-fs-backend'
-import { initReactI18next } from 'react-i18next'
 
 const options = {
   lng: 'en',

--- a/locales/en/connection.json
+++ b/locales/en/connection.json
@@ -1,0 +1,5 @@
+{
+  "connectionFailed": "Connection failed.",
+  "keys": "keys",
+  "retry": "Retry?"
+}

--- a/locales/en/connectionList.json
+++ b/locales/en/connectionList.json
@@ -1,0 +1,3 @@
+{
+  "title": "CONNECTIONS"
+}

--- a/locales/en/keyContent.json
+++ b/locales/en/keyContent.json
@@ -1,0 +1,3 @@
+{
+  "empty": "No key selected"
+}

--- a/locales/en/keyList.json
+++ b/locales/en/keyList.json
@@ -1,0 +1,5 @@
+{
+  "empty": "No database selected",
+  "search": "Search...",
+  "keys": "keys"
+}

--- a/locales/en/newConnection.json
+++ b/locales/en/newConnection.json
@@ -1,0 +1,13 @@
+{
+  "title": "New connection",
+  "form": {
+    "name": "Connection name",
+    "host": "Host",
+    "port": "Port",
+    "password": "Password",
+    "passwordHint": "Leave empty for no password",
+    "test": "Test connection",
+    "cancel": "Cancel",
+    "save": "Save"
+  }
+}

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -3,14 +3,6 @@
     "title": "CONNECTIONS"
   },
   "newConnection": {
-    "title": "New connection",
-    "connectionName": "Connection name",
-    "host": "Host",
-    "port": "Port",
-    "password": "Password",
-    "passwordHint": "Leave empty for no password",
-    "testConnectionButtonLabel": "Test connection",
-    "cancelButtonLabel": "Cancel",
-    "saveButtonLabel": "Save"
+    
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-resizable": "1.10.1",
     "react-spring": "8.0.27",
     "react-use": "15.3.2",
+    "react-virtual": "2.2.1",
     "recoil": "0.0.10",
     "styled-components": "5.1.1",
     "uuidv4": "6.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import Modal from 'react-modal'
+
 import { RecoilRoot } from 'recoil'
 import { ThemeProvider } from 'styled-components'
 

--- a/src/atoms/connections.ts
+++ b/src/atoms/connections.ts
@@ -11,6 +11,7 @@ export interface IConnection {
 
 export interface IDatabase {
   name: string
+  index: number
   keys: number
 }
 
@@ -26,5 +27,10 @@ export const currentConnectionState = atom<IConnection | undefined>({
 
 export const currentDatabaseState = atom<IDatabase | undefined>({
   key: 'currentDatabase',
+  default: undefined
+})
+
+export const currentKeyState = atom<string | undefined>({
+  key: 'currentKey',
   default: undefined
 })

--- a/src/components/EmptyContent/index.tsx
+++ b/src/components/EmptyContent/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { FiBook } from 'react-icons/fi'
+
+import { Container } from './styles'
+
+interface EmptyContentProps {
+  message: string
+}
+
+const EmptyContent: React.FC<EmptyContentProps> = ({ message }) => {
+  return (
+    <Container>
+      <FiBook />
+      <p>{message}</p>
+    </Container>
+  )
+}
+
+export default EmptyContent

--- a/src/components/EmptyContent/styles.ts
+++ b/src/components/EmptyContent/styles.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  svg {
+    width: 150px;
+    height: 120px;
+    stroke: #322d41;
+    stroke-width: 0.8px;
+  }
+
+  p {
+    margin-top: 14px;
+    font-size: 20px;
+    font-weight: bold;
+    color: #322d41;
+
+    text-align: center;
+  }
+`

--- a/src/components/Form/Input/index.tsx
+++ b/src/components/Form/Input/index.tsx
@@ -1,4 +1,3 @@
-import { useField } from '@unform/core'
 import React, {
   useState,
   useCallback,
@@ -8,6 +7,8 @@ import React, {
   memo
 } from 'react'
 import { FiAlertCircle } from 'react-icons/fi'
+
+import { useField } from '@unform/core'
 
 import { Container, TitleContainer, InputContainer } from './styles'
 
@@ -37,13 +38,13 @@ const Input: React.FC<InputProps> = ({ label, name, hint, ...rest }) => {
         ref: inputRef.current
       })
     }
-  }, [])
+  }, [registerField, fieldName])
 
   const handleInputFocus = useCallback(() => {
     setIsFocused(true)
 
     clearError()
-  }, [])
+  }, [clearError])
 
   const handleInputBlur = useCallback(() => {
     setIsFocused(false)

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, memo, ReactNode } from 'react'
+import React, { useState, useCallback, useEffect, memo } from 'react'
 import ReactModal from 'react-modal'
 
 import { Container } from './styles'
@@ -27,7 +27,7 @@ const Modal: React.FC<ModalProps> = ({
     }
 
     setIsOpen(false)
-  }, [])
+  }, [onRequestClose])
 
   return (
     <ReactModal

--- a/src/components/ToastContainer/Toast/styles.ts
+++ b/src/components/ToastContainer/Toast/styles.ts
@@ -1,4 +1,5 @@
 import { animated } from 'react-spring'
+
 import styled, { css } from 'styled-components'
 
 interface ContainerProps {

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useContext, useCallback } from 'react'
+
 import { uuid } from 'uuidv4'
 
 import ToastContainer from '../components/ToastContainer'

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -19,7 +19,7 @@ export function useConfig<K extends keyof Schema>(
     })
 
     return unsubscribe
-  }, [])
+  }, [key])
 
   return value
 }

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -33,7 +33,7 @@ export function useWindowSize({
         window.removeEventListener('resize', handleResize)
       }
     }
-  }, [])
+  }, [watch])
 
   return windowSize
 }

--- a/src/screen/ConnectionsList/Connection/index.tsx
+++ b/src/screen/ConnectionsList/Connection/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useCallback, useMemo, useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FiDatabase, FiChevronRight, FiLoader } from 'react-icons/fi'
 
 import { useRecoilState, useSetRecoilState } from 'recoil'
@@ -36,6 +37,7 @@ const Connection: React.FC<IConnectionProps> = ({ connection }) => {
   const [databases, setDatabases] = useState<IDatabase[]>([])
   const [isConnecting, setIsConnecting] = useState(false)
   const [isConnectionFailed, setIsConnectionFailed] = useState(false)
+  const { t } = useTranslation('connection')
 
   const { addToast } = useToast()
 
@@ -126,7 +128,9 @@ const Connection: React.FC<IConnectionProps> = ({ connection }) => {
               type="button"
             >
               <strong>{database.name}</strong>
-              <span>{database.keys} keys</span>
+              <span>
+                {database.keys} {t('keys')}
+              </span>
             </Database>
           ))}
         </DatabaseList>
@@ -134,9 +138,9 @@ const Connection: React.FC<IConnectionProps> = ({ connection }) => {
 
       {isConnectionFailed && (
         <ConnectionError>
-          Connection failed.{' '}
+          {t('connectionFailed')}{' '}
           <button type="button" onClick={handleConnect}>
-            Retry?
+            {t('retry')}
           </button>
         </ConnectionError>
       )}

--- a/src/screen/ConnectionsList/Connection/index.tsx
+++ b/src/screen/ConnectionsList/Connection/index.tsx
@@ -47,7 +47,7 @@ const Connection: React.FC<IConnectionProps> = ({ connection }) => {
 
   const isConnected = useMemo(() => {
     return currentConnection?.name === connection.name
-  }, [currentConnection?.name])
+  }, [currentConnection?.name, connection.name])
 
   const handleConnect = useCallback(async () => {
     if (!isConnected) {
@@ -95,7 +95,7 @@ const Connection: React.FC<IConnectionProps> = ({ connection }) => {
         })
       }
     },
-    [currentConnection]
+    [currentConnection, addToast, setCurrentDatabase]
   )
 
   return (

--- a/src/screen/ConnectionsList/NewConnectionModal/index.tsx
+++ b/src/screen/ConnectionsList/NewConnectionModal/index.tsx
@@ -1,8 +1,9 @@
-import { FormHandles } from '@unform/core'
-import { Form } from '@unform/web'
 import React, { useRef, useCallback, memo } from 'react'
 import { FiActivity, FiSave } from 'react-icons/fi'
 import { useToggle } from 'react-use'
+
+import { FormHandles } from '@unform/core'
+import { Form } from '@unform/web'
 import { useSetRecoilState } from 'recoil'
 import * as Yup from 'yup'
 
@@ -40,6 +41,12 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
   const [createConnectionLoading, toggleCreateConnectionLoading] = useToggle(
     false
   )
+
+  const handleCloseModal = useCallback(() => {
+    if (onRequestClose) {
+      onRequestClose()
+    }
+  }, [onRequestClose])
 
   const handleCreateConnection = useCallback(
     async (data: ConnectionFormData) => {
@@ -95,7 +102,7 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
         toggleCreateConnectionLoading()
       }
     },
-    []
+    [addToast, setConnections, toggleCreateConnectionLoading, handleCloseModal]
   )
 
   const handleTestConnection = useCallback(async () => {
@@ -151,13 +158,7 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
     } finally {
       toggleTestConnectionLoading()
     }
-  }, [])
-
-  const handleCloseModal = useCallback(() => {
-    if (onRequestClose) {
-      onRequestClose()
-    }
-  }, [])
+  }, [addToast, toggleTestConnectionLoading])
 
   return (
     <Modal visible={visible} onRequestClose={onRequestClose}>

--- a/src/screen/ConnectionsList/NewConnectionModal/index.tsx
+++ b/src/screen/ConnectionsList/NewConnectionModal/index.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useCallback, memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FiActivity, FiSave } from 'react-icons/fi'
 import { useToggle } from 'react-use'
 
@@ -36,6 +37,7 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
   const formRef = useRef<FormHandles>(null)
   const { addToast } = useToast()
   const setConnections = useSetRecoilState(connectionsState)
+  const { t } = useTranslation('newConnection')
 
   const [testConnectionLoading, toggleTestConnectionLoading] = useToggle(false)
   const [createConnectionLoading, toggleCreateConnectionLoading] = useToggle(
@@ -162,7 +164,7 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
 
   return (
     <Modal visible={visible} onRequestClose={onRequestClose}>
-      <h1>New connection</h1>
+      <h1>{t('title')}</h1>
 
       <Form
         initialData={{
@@ -172,18 +174,18 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
         ref={formRef}
         onSubmit={handleCreateConnection}
       >
-        <Input name="name" label="Connection name" />
+        <Input name="name" label={t('form.name')} />
 
         <InputGroup>
-          <Input name="host" label="Host" />
-          <Input name="port" label="Port" />
+          <Input name="host" label={t('form.host')} />
+          <Input name="port" label={t('form.port')} />
         </InputGroup>
 
         <Input
           type="password"
           name="password"
-          label="Password"
-          hint="Leave empty for no password"
+          label={t('form.password')}
+          hint={t('form.passwordHint')}
         />
 
         <ActionsContainer>
@@ -193,12 +195,12 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
             onClick={handleTestConnection}
           >
             <FiActivity />
-            Test connection
+            {t('form.test')}
           </TestConnectionButton>
 
           <ButtonGroup>
             <Button onClick={handleCloseModal} type="button" color="opaque">
-              Cancel
+              {t('form.cancel')}
             </Button>
             <Button
               loading={createConnectionLoading}
@@ -206,7 +208,7 @@ const NewConnectionModal: React.FC<SharedModalProps> = ({
               color="purple"
             >
               <FiSave />
-              Save
+              {t('form.save')}
             </Button>
           </ButtonGroup>
         </ActionsContainer>

--- a/src/screen/ConnectionsList/index.tsx
+++ b/src/screen/ConnectionsList/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FiPlusCircle } from 'react-icons/fi'
 import { useToggle } from 'react-use'
 
@@ -12,6 +13,7 @@ import { Container, Connections } from './styles'
 const ConnectionsList: React.FC = () => {
   const [connections] = useRecoilState(connectionsState)
   const [isCreateModalOpen, toggleCreateModalOpen] = useToggle(false)
+  const { t } = useTranslation('connectionList')
 
   return (
     <>
@@ -24,7 +26,7 @@ const ConnectionsList: React.FC = () => {
       >
         <Connections>
           <header>
-            <strong>CONNECTIONS</strong>
+            <strong>{t('title')}</strong>
             <button type="button" onClick={toggleCreateModalOpen}>
               <FiPlusCircle />
             </button>

--- a/src/screen/ConnectionsList/index.tsx
+++ b/src/screen/ConnectionsList/index.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react'
 import { FiPlusCircle } from 'react-icons/fi'
 import { useToggle } from 'react-use'
+
 import { useRecoilState } from 'recoil'
 
 import { connectionsState } from '../../atoms/connections'

--- a/src/screen/ConnectionsList/styles.ts
+++ b/src/screen/ConnectionsList/styles.ts
@@ -1,4 +1,5 @@
 import { ResizableBox } from 'react-resizable'
+
 import styled from 'styled-components'
 
 export const Container = styled(ResizableBox).attrs({

--- a/src/screen/Header/index.tsx
+++ b/src/screen/Header/index.tsx
@@ -1,7 +1,8 @@
-import { remote } from 'electron'
-import os from 'os'
 import React, { useCallback, useMemo, memo } from 'react'
 import { FiX, FiMinus, FiMaximize2, FiSquare } from 'react-icons/fi'
+
+import { remote } from 'electron'
+import os from 'os'
 
 import { useConfig } from '../../hooks/useConfig'
 import {

--- a/src/screen/KeyContent/index.tsx
+++ b/src/screen/KeyContent/index.tsx
@@ -1,13 +1,33 @@
-import React, { memo } from 'react'
-import { FiBook } from 'react-icons/fi'
+import React, { memo, useEffect, useState } from 'react'
 
+import { useRecoilValue } from 'recoil'
+
+import { currentKeyState } from '../../atoms/connections'
+import EmptyContent from '../../components/EmptyContent'
+import { loadKeyContent, IKeyContent } from '../../services/key/LoadKeyContent'
 import { Container } from './styles'
 
 const KeyContent: React.FC = () => {
+  const currentKey = useRecoilValue(currentKeyState)
+  const [keyContent, setKeyContent] = useState<IKeyContent | null>(null)
+
+  useEffect(() => {
+    if (currentKey) {
+      loadKeyContent(currentKey).then(content => {
+        if (content) {
+          setKeyContent(content)
+        }
+      })
+    }
+  }, [currentKey])
+
   return (
     <Container>
-      <FiBook />
-      <p>No Key Selected</p>
+      {!currentKey ? (
+        <EmptyContent message="No key selected" />
+      ) : (
+        <div>{keyContent?.content}</div>
+      )}
     </Container>
   )
 }

--- a/src/screen/KeyContent/index.tsx
+++ b/src/screen/KeyContent/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { useRecoilValue } from 'recoil'
 
@@ -10,6 +11,7 @@ import { Container } from './styles'
 const KeyContent: React.FC = () => {
   const currentKey = useRecoilValue(currentKeyState)
   const [keyContent, setKeyContent] = useState<IKeyContent | null>(null)
+  const { t } = useTranslation('keyContent')
 
   useEffect(() => {
     if (currentKey) {
@@ -24,7 +26,7 @@ const KeyContent: React.FC = () => {
   return (
     <Container>
       {!currentKey ? (
-        <EmptyContent message="No key selected" />
+        <EmptyContent message={t('empty')} />
       ) : (
         <div>{keyContent?.content}</div>
       )}

--- a/src/screen/KeyContent/styles.ts
+++ b/src/screen/KeyContent/styles.ts
@@ -1,28 +1,7 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-  display: flex;
   flex: 1;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
   padding: 16px;
   background: ${props => props.theme.backgrounds.darker};
-
-  svg {
-    width: 150px;
-    height: 120px;
-    stroke: #322d41;
-    stroke-width: 0.8px;
-  }
-
-  p {
-    margin-top: 14px;
-    font-size: 20px;
-    font-weight: bold;
-    color: #322d41;
-
-    text-align: center;
-  }
 `

--- a/src/screen/KeyList/SearchInput/index.tsx
+++ b/src/screen/KeyList/SearchInput/index.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, InputHTMLAttributes } from 'react'
 import { FiSearch } from 'react-icons/fi'
 
 import { Container } from './styles'
 
-const SearchInput: React.FC = ({ ...rest }) => {
+type SearchInputProps = InputHTMLAttributes<HTMLInputElement>
+
+const SearchInput: React.FC<SearchInputProps> = ({ ...rest }) => {
   const [isFocused, setIsFocused] = useState(false)
 
   const handleInputFocus = useCallback(() => {

--- a/src/screen/KeyList/SearchInput/index.tsx
+++ b/src/screen/KeyList/SearchInput/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, InputHTMLAttributes } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FiSearch } from 'react-icons/fi'
 
 import { Container } from './styles'
@@ -7,6 +8,7 @@ type SearchInputProps = InputHTMLAttributes<HTMLInputElement>
 
 const SearchInput: React.FC<SearchInputProps> = ({ ...rest }) => {
   const [isFocused, setIsFocused] = useState(false)
+  const { t } = useTranslation('keyList')
 
   const handleInputFocus = useCallback(() => {
     setIsFocused(true)
@@ -19,7 +21,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ ...rest }) => {
   return (
     <Container isFocused={isFocused} onFocus={handleInputFocus}>
       <FiSearch />
-      <input placeholder="Search..." {...rest} onBlur={handleInputBlur} />
+      <input placeholder={t('search')} {...rest} onBlur={handleInputBlur} />
     </Container>
   )
 }

--- a/src/screen/KeyList/SearchInput/styles.tsx
+++ b/src/screen/KeyList/SearchInput/styles.tsx
@@ -8,12 +8,12 @@ export const Container = styled.div<InputContainerProps>`
   flex: 1;
   display: flex;
   align-items: center;
-  max-width: 300px;
+  max-width: 260px;
   border-radius: 4px;
   background: ${props => props.theme.backgrounds.darkest};
   border: 1px solid #322d41;
 
-  padding: 8px 16px;
+  padding: 7px 12px;
 
   transition: border 0.2s;
 

--- a/src/screen/KeyList/index.tsx
+++ b/src/screen/KeyList/index.tsx
@@ -76,9 +76,12 @@ const KeyList: React.FC = () => {
     []
   )
 
-  const handleSelectKey = useCallback((key: string) => {
-    setCurrentKey(key)
-  }, [])
+  const handleSelectKey = useCallback(
+    (key: string) => {
+      setCurrentKey(key)
+    },
+    [setCurrentKey]
+  )
 
   useEffect(() => {
     if (currentDatabase) {

--- a/src/screen/KeyList/index.tsx
+++ b/src/screen/KeyList/index.tsx
@@ -7,6 +7,7 @@ import React, {
   ChangeEvent,
   useMemo
 } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useDebounce } from 'react-use'
 import { useVirtual } from 'react-virtual'
 
@@ -38,6 +39,7 @@ const KeyList: React.FC = () => {
   const parentRef = useRef(null)
 
   const { width } = useWindowSize({ watch: false })
+  const { t } = useTranslation('keyList')
 
   const [searchInputValue, setSearchInputValue] = useState('')
   const [filter, setFilter] = useState('')
@@ -105,7 +107,9 @@ const KeyList: React.FC = () => {
               <HeaderTitle>{currentConnection?.name}</HeaderTitle>
               <HeaderDatabaseDetails>
                 <span>{currentDatabase?.name}</span>
-                <span>{currentDatabase?.keys} keys</span>
+                <span>
+                  {currentDatabase?.keys} {t('keys')}
+                </span>
               </HeaderDatabaseDetails>
             </HeaderTextContainer>
             <SearchInput
@@ -148,7 +152,7 @@ const KeyList: React.FC = () => {
           </KeyListWrapper>
         </>
       ) : (
-        <EmptyContent message="No database selected" />
+        <EmptyContent message={t('empty')} />
       )}
     </Container>
   )

--- a/src/screen/KeyList/styles.ts
+++ b/src/screen/KeyList/styles.ts
@@ -1,5 +1,7 @@
 import { ResizableBox } from 'react-resizable'
-import styled from 'styled-components'
+
+import { transparentize } from 'polished'
+import styled, { css } from 'styled-components'
 
 export const Container = styled(ResizableBox).attrs({
   resizeHandles: ['e'],
@@ -7,7 +9,11 @@ export const Container = styled(ResizableBox).attrs({
 })`
   height: 100%;
   padding: 24px;
+  border-right: 1px solid ${props => props.theme.backgrounds.lightest};
+  display: flex;
+  flex-direction: column;
 `
+
 export const Header = styled.header`
   display: flex;
   flex-direction: row;
@@ -28,37 +34,81 @@ export const HeaderTitle = styled.p`
   line-height: 24px;
 `
 
-export const HeaderTotalKeys = styled.p`
+export const HeaderDatabaseDetails = styled.p`
   font-weight: normal;
   font-size: 12px;
   line-height: 14px;
   color: #9696a7;
   margin-left: 8px;
+
+  span + span {
+    margin-left: 8px;
+    padding-left: 8px;
+    border-left: 1px solid rgba(255, 255, 255, 0.1);
+  }
+`
+
+export const KeyListWrapper = styled.div`
+  height: calc(100vh - 140px);
+  overflow: auto;
+  margin-top: 18px;
 `
 
 export const KeyListContainer = styled.section`
-  margin-top: 18px;
+  position: relative;
 `
 
 export const Key = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: center;
   justify-content: space-between;
   padding: 8px 0;
 
-  &:not(:last-child) {
-    border-bottom: 1px solid rgba(225, 225, 230, 0.1);
+  & + div {
+    border-top: 1px solid rgba(225, 225, 230, 0.1);
   }
 
-  svg {
-    color: #9696a7;
+  button {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+
+    svg {
+      color: ${props => props.theme.colors.grey};
+      width: 14px;
+      height: 14px;
+    }
+
+    &:hover svg {
+      color: ${props => props.theme.colors.white};
+    }
   }
 `
 
-export const KeyTextContainer = styled.div`
+interface KeyTextContainerProps {
+  selected: boolean
+}
+
+export const KeyTextContainer = styled.button<KeyTextContainerProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
+  color: ${props => props.theme.colors.white};
+
+  ${props =>
+    !props.selected &&
+    css`
+      &:hover {
+        color: ${props => transparentize(0.2, props.theme.colors.pink)};
+      }
+    `}
+
+  ${props =>
+    props.selected &&
+    css`
+      color: ${props.theme.colors.pink};
+    `}
 `
 
 export const KeyTitle = styled.p`

--- a/src/services/RedisConnection.ts
+++ b/src/services/RedisConnection.ts
@@ -1,0 +1,36 @@
+import Redis, { Redis as RedisConnection } from 'ioredis'
+
+import { IConnection, IDatabase } from '../atoms/connections'
+
+let connection: RedisConnection | undefined
+
+function initializeConnection(
+  connectionOptions: IConnection,
+  database: IDatabase
+): Promise<void> {
+  if (connection) {
+    connection.disconnect()
+  }
+
+  return new Promise((resolve, reject) => {
+    connection = new Redis(connectionOptions.port, connectionOptions.host, {
+      enableReadyCheck: true,
+      connectTimeout: 3000,
+      password: connectionOptions.password,
+      db: database.index,
+      retryStrategy() {
+        return null
+      }
+    })
+
+    connection.once('ready', async () => {
+      resolve()
+    })
+
+    connection.once('error', () => {
+      reject(new Error())
+    })
+  })
+}
+
+export { connection, initializeConnection }

--- a/src/services/connection/LoadConnectionDatabases.ts
+++ b/src/services/connection/LoadConnectionDatabases.ts
@@ -22,17 +22,18 @@ export function loadConnectionDatabases(
         .split('\n')
         .slice(1)
         .reduce((databases: IDatabase[] = [], databaseLine) => {
-          const matched = /(db[0-9]{1,}):keys=([0-9]{1,}).+/gi.exec(
+          const matched = /db([0-9]{1,}):keys=([0-9]{1,}).+/gi.exec(
             databaseLine
           )
 
           if (matched) {
-            const [, db, keys] = matched
+            const [, index, keys] = matched
 
             return [
               ...databases,
               {
-                name: db,
+                name: `db${index}`,
+                index: Number(index),
                 keys: Number(keys)
               }
             ]

--- a/src/services/database/LoadKeysFromDatabase.ts
+++ b/src/services/database/LoadKeysFromDatabase.ts
@@ -1,0 +1,11 @@
+import { connection } from '../RedisConnection'
+
+export async function loadKeysFromDatabase(): Promise<string[]> {
+  if (!connection) {
+    throw new Error('Redis connection not established')
+  }
+
+  const keys = connection.keys('*')
+
+  return keys
+}

--- a/src/services/key/LoadKeyContent.ts
+++ b/src/services/key/LoadKeyContent.ts
@@ -1,0 +1,44 @@
+import { connection } from '../RedisConnection'
+
+export interface IKeyContent {
+  content: string | null
+  type: 'hash' | 'list' | 'string'
+}
+
+export async function loadKeyContent(key: string): Promise<IKeyContent> {
+  if (!connection) {
+    throw new Error('Redis connection not established')
+  }
+
+  const keyType = await connection.type(key)
+  const type = keyType as IKeyContent['type']
+
+  let content: string | null = ''
+
+  if (!['hash', 'list', 'string'].includes(type)) {
+    throw new Error('Key type not supported yet.')
+  }
+
+  switch (type) {
+    case 'hash': {
+      const hashValue = await connection.hgetall(key)
+
+      content = JSON.stringify(hashValue)
+      break
+    }
+    case 'list': {
+      const listValue = await connection.lrange(key, 0, -1)
+
+      content = JSON.stringify(listValue)
+      break
+    }
+    default: {
+      content = await connection.get(key)
+    }
+  }
+
+  return {
+    content,
+    type
+  }
+}

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -74,4 +74,20 @@ export const GlobalStyle = createGlobalStyle`
       outline: 0;
     }
   }
+
+  ::-webkit-scrollbar {
+    width: 8px;
+
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.05);
+  }
+  
+  ::-webkit-scrollbar-track {
+    border-radius: 4px;
+  }
+  
+  ::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+  }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,6 +1447,11 @@
     native-url "^0.2.6"
     schema-utils "^2.6.5"
 
+"@reach/observe-rect@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
+  integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -8673,6 +8678,14 @@ react-use@15.3.2:
     ts-easing "^0.2.0"
     tslib "^2.0.0"
 
+react-virtual@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-virtual/-/react-virtual-2.2.1.tgz#639741f203b683630457836e85ddbba7a732d9b5"
+  integrity sha512-71wjhbm/WgFRKaaS/oAN6znUpQkdSdbRfg3jCyvgP45QAbBKH3lSiTR/nLawgqhlwGjcYp9jN94MLNW1UVoobQ==
+  dependencies:
+    "@reach/observe-rect" "^1.1.0"
+    ts-toolbelt "^6.4.2"
+
 react@16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -10316,6 +10329,11 @@ ts-jest@26.1.2:
     mkdirp "1.x"
     semver "7.x"
     yargs-parser "18.x"
+
+ts-toolbelt@^6.4.2:
+  version "6.13.6"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.13.6.tgz#4c9fad69bb3389323fe60982f18cd06b72f7d42a"
+  integrity sha512-qqIexrhqCNOuSRCrJMOKor8UJxA4DYMB6fNpBmRAKJgmLXNj8TAiuCrs7Nm08fva+MEdQhEXmsnjBQarNSIWZg==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
Add the key listing section when user selected a database. Also, the user can search through the
list. When the key get clicked, a preview is shown on the right sidebar, but not styled yet.

fix #36