### PR TITLE
feat: adds word-break to KeyContent screen

### DIFF
--- a/src/screen/KeyContent/styles.ts
+++ b/src/screen/KeyContent/styles.ts
@@ -4,4 +4,8 @@ export const Container = styled.div`
   flex: 1;
   padding: 16px;
   background: ${props => props.theme.backgrounds.darker};
+  
+  div {
+    word-break: break-word;
+  }
 `


### PR DESCRIPTION
I was having some trouble with a really big content and couldn't read it entirely, adding word-break fixed it.